### PR TITLE
Fallback reading passwords from environment variables

### DIFF
--- a/main.js
+++ b/main.js
@@ -141,13 +141,13 @@ function setEmptyState(state, emptyState) {
 function processFlags(flags) {
   // Flags override values in config file.
   if (elternPortalConfigured()) { // section may be absent
-    CONFIG.elternportal.pass = flags.ep_password || CONFIG.elternportal.pass;
+    CONFIG.elternportal.pass = flags.ep_password || CONFIG.elternportal.pass || process.env.EP_PASSWORD;
   }
   if (schulmanagerConfigured()) { // section may be absent
-    CONFIG.schulmanager.pass = flags.sm_password || CONFIG.schulmanager.pass;
+    CONFIG.schulmanager.pass = flags.sm_password || CONFIG.schulmanager.pass || process.env.SM_PASSWORD;
   }
-  CONFIG.smtp.auth.pass = flags.smtp_password || CONFIG.smtp.auth.pass;
-  CONFIG.imap.auth.pass = flags.imap_password || CONFIG.imap.auth.pass;
+  CONFIG.smtp.auth.pass = flags.smtp_password || CONFIG.smtp.auth.pass || process.env.SMTP_PASSWORD;
+  CONFIG.imap.auth.pass = flags.imap_password || CONFIG.imap.auth.pass || process.env.IMAP_PASSWORD;
   CONFIG.options.mute = flags.mute !== undefined ? flags.mute : CONFIG.options.mute;
   CONFIG.options.once = flags.once !== undefined ? flags.once : CONFIG.options.once;
   CONFIG.options.test = flags.test !== undefined ? flags.test : CONFIG.options.test;

--- a/text.md
+++ b/text.md
@@ -269,6 +269,12 @@ The following flags are supported:
 * `--smtp_password=abc123` Specify the SMTP server password.
 * `--imap_password=abc123` Specify the IMAP server password.
 
+Passwords are accept from different sources with the following priority:
+1. Passwords specified on the command line override passwords from `config.json`
+2. Passwords in `config.json` are the default
+3. Passwords from environment variables are taken as fallback, if there is neither a password in
+   `config.json` nor on the command line
+
 ## Environment variables
 
 The following environment variables are supported:

--- a/text.md
+++ b/text.md
@@ -269,6 +269,15 @@ The following flags are supported:
 * `--smtp_password=abc123` Specify the SMTP server password.
 * `--imap_password=abc123` Specify the IMAP server password.
 
+## Environment variables
+
+The following environment variables are supported:
+
+* `EP_PASSWORD` Specify the Eltern-Portal login password.
+* `SM_PASSWORD` Specify the Schulmanager login password.
+* `SMTP_PASSWORD` Specify the SMTP server password.
+* `IMAP_PASSWORD` Specify the IMAP server password.
+
 ## Log File
 
 Log messages are shown on the console and written to the file `eltern-emailer.log` Log files are rotated at 10MB, keeping at most three files. The log level can be set in the config file. It defaults to `debug`.


### PR DESCRIPTION
I'm not happy with the current options to pass passwords:
- a config file containing passwords shall not checked in into a git repository
- command line arguments are visible to other users using `ps`

Therefore I'd like to use environment variables as suggested in https://12factor.net/config.
It's implemented as a fallback, so the previous methods override it.

In kubernetes this option allows [passing secrets as environment variables](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data), preferably in combination with [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets).
